### PR TITLE
WIP: Emit frontmatter

### DIFF
--- a/include/standardese/markup/generator.hpp
+++ b/include/standardese/markup/generator.hpp
@@ -5,6 +5,8 @@
 #ifndef STANDARDESE_MARKUP_GENERATOR_HPP_INCLUDED
 #define STANDARDESE_MARKUP_GENERATOR_HPP_INCLUDED
 
+#include <boost/filesystem.hpp>
+
 #include <functional>
 #include <iosfwd>
 #include <string>
@@ -44,14 +46,14 @@ namespace markup
     /// If `use_html` is `true`, it will use HTML for complex parts that cannot be described using
     /// CommonMark.
     generator markdown_generator(bool use_html, const std::string& link_prefix,
-                                 const std::string& extension) noexcept;
+                                 const std::string& extension, const boost::filesystem::path& root = boost::filesystem::current_path()) noexcept;
 
     /// Renders an entity as CommonMark.
     ///
     /// \returns `render(commonmark_generator(), e)`.
     inline std::string as_markdown(const entity& e)
     {
-        return render(markdown_generator(true, "", "md"), e);
+        return render(markdown_generator(true, "", "md", boost::filesystem::current_path()), e);
     }
 
     /// A plain text generator.

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -89,6 +89,9 @@ target_link_libraries(standardese PUBLIC cppast)
 # link cmark
 target_link_libraries(standardese PUBLIC libcmark-gfm_static)
 
+# link yaml-cpp
+target_link_libraries(standardese PUBLIC -lyaml-cpp)
+
 # install library: TODO
 #install(TARGETS standardese EXPORT standardese DESTINATION "${lib_dest}")
 #install(FILES ${header} DESTINATION "${include_dest}/standardese")

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -91,6 +91,7 @@ target_link_libraries(standardese PUBLIC libcmark-gfm_static)
 
 # link yaml-cpp
 target_link_libraries(standardese PUBLIC -lyaml-cpp)
+target_link_libraries(standardese PUBLIC -lboost_filesystem)
 
 # install library: TODO
 #install(TARGETS standardese EXPORT standardese DESTINATION "${lib_dest}")

--- a/tool/main.cpp
+++ b/tool/main.cpp
@@ -260,8 +260,8 @@ std::vector<std::pair<standardese::markup::generator, const char*>> get_formats(
             formats.emplace_back(standardese::markup::xml_generator(), "xml");
         else if (format == "commonmark")
             formats.emplace_back(standardese::markup::markdown_generator(false, link_prefix,
-                                                                         link_extension.value_or(
-                                                                             "md")),
+                                                                         link_extension.value_or("md"),
+                                                                         boost::filesystem::path(get_option<std::string>(options, "output.root").value())),
                                  "md");
         else if (format == "commonmark_html")
             formats.emplace_back(standardese::markup::markdown_generator(true, link_prefix,
@@ -393,6 +393,8 @@ int main(int argc, char* argv[])
         ("output.prefix",
          po::value<std::string>()->default_value(""),
          "a prefix that will be added to all output files")
+        ("output.root",
+         po::value<std::string>()->default_value(boost::filesystem::current_path().generic_string()))
         ("output.format",
          po::value<std::vector<std::string>>()->default_value(std::vector<std::string>{"html"}, "{html}"),
          "the output format used (html, commonmark, commonmark_html, xml, text)")


### PR DESCRIPTION
For postprocessing with jekyll and such, it's very helpful to store some metadata in the frontmatter of the created `.md` files.