### PR TITLE
Drop GitHub templates

### DIFF
--- a/.github/issue_template
+++ b/.github/issue_template
@@ -1,3 +1,0 @@
-<!--- When submitting a bug report,
-please provide both the source code that causes the failure
-and the full output of standardese with the verbose option set (i.e. standardese --verbose ...). --->

--- a/.github/pull_request_template
+++ b/.github/pull_request_template
@@ -1,3 +1,0 @@
-<!--- When initiating a pull request, please use the develop branch as base.
-If it is a critical hotfix I'll manually merge it directly onto master.
-Please format everything using clang-format. --->


### PR DESCRIPTION
the PR template is not correct anymore since we dropped develop. Since
nobody has filed issues for a while, I am not sure whether the issue one
is accurate but we probably might want to reword it a bit.