### PR TITLE
Update badges in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,8 +6,7 @@
 
 <p align="center">
   <img src="https://img.shields.io/badge/License-MIT-blue.svg" alt="License: MIT">
-  <a href="https://travis-ci.org/foonathan/standardese"><img src="https://travis-ci.org/foonathan/standardese.svg?branch=master" alt="Travis CI"></a>
-  <a href="https://ci.appveyor.com/project/foonathan/standardese/branch/master"><img src="https://ci.appveyor.com/api/projects/status/1aw8ml5lawu4mtyv/branch/master?svg=true" alt="Appveyor"></a>
+  <a href="https://travis-ci.org/standardese/standardese"><img src="https://travis-ci.org/standardese/standardese.svg?branch=master" alt="Travis CI"></a>
   <a href="https://gitter.im/foonathan/standardese"><img src="https://badges.gitter.im/foonathan/standardese.svg" alt="Gitter"></a>
 </p>
 


### PR DESCRIPTION
We do not support appveyor currently. We probably won't go back to
AppVeyor with #143.