### PR TITLE
Build with shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,8 +5,9 @@
 cmake_minimum_required(VERSION 3.1)
 project(STANDARDESE VERSION 0.4.1)
 
-option(STANDARDESE_BUILD_TOOL "whether or not to build the tool" ON)
-option(STANDARDESE_BUILD_TEST "whether or not to build the test" ON)
+option(STANDARDESE_BUILD_TOOL "Build the standardese binary" ON)
+option(STANDARDESE_BUILD_TEST "Build the standardese test suite" ON)
+option(BUILD_SHARED_LIBS "Build shared libraries (.dll/.so/.dylib) instead of static ones (.lib/.a)" ON)
 
 set(lib_dest "lib/standardese")
 set(include_dest "include")
@@ -24,8 +25,6 @@ if (MSVC)
         /MP # Multi-processor compilation
         )
 endif()
-
-add_definitions(-DBOOST_ALL_NO_LIB) # Disable auto-link
 
 # subdirectories
 add_subdirectory(src)

--- a/news/shared.rst
+++ b/news/shared.rst
@@ -1,0 +1,4 @@
+**Fixed:**
+
+* Build as shared library and link against a shared boost library unless told
+  not to.

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -11,11 +11,6 @@ target_include_directories(standardese_tool PUBLIC $<BUILD_INTERFACE:${THREADPOO
 set_target_properties(standardese_tool PROPERTIES OUTPUT_NAME standardese CXX_STANDARD 11)
 
 # link Boost
-
-# Force linking to static libraries. Linking Boost.ProgramOptions dynamic library causes link errors
-# See for example http://stackoverflow.com/questions/11235927/link-to-static-boost-lib-with-cmake-and-vs2010-without-automatic-linking.
-set(Boost_USE_STATIC_LIBS ON)
-
 find_package(Boost COMPONENTS program_options filesystem system REQUIRED)
 target_include_directories(standardese_tool PUBLIC ${Boost_INCLUDE_DIR})
 target_link_libraries(standardese_tool PUBLIC ${Boost_LIBRARIES})


### PR DESCRIPTION
static libraries are frowned upon by most distributions which means that
this has to be patched away. So, shared seems to be the better default.
There is now a configuration switch that can be used to build statically
anyway.