### PR TITLE
Require a C++17 compiler to build standardese

### DIFF
--- a/news/cpp17.rst
+++ b/news/cpp17.rst
@@ -1,0 +1,3 @@
+**Changed:**
+
+* Require a C++17 compiler to build standardese

--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -8,7 +8,7 @@ set(src generator.cpp main.cpp)
 add_executable(standardese_tool ${header} ${src})
 target_link_libraries(standardese_tool PUBLIC standardese)
 target_include_directories(standardese_tool PUBLIC $<BUILD_INTERFACE:${THREADPOOL_INCLUDE_DIR}>)
-set_target_properties(standardese_tool PROPERTIES OUTPUT_NAME standardese CXX_STANDARD 11)
+set_target_properties(standardese_tool PROPERTIES OUTPUT_NAME standardese CXX_STANDARD 17)
 
 # link Boost
 


### PR DESCRIPTION
I don't really see the use case that would have you build standardese in
an old stack. So we should not make our lives harder by supporting C++11
compilers.