### PR TITLE
explain how to use Doxygen LaTeX delimiters

### DIFF
--- a/examples/mathjax/doc/_includes/footer.html
+++ b/examples/mathjax/doc/_includes/footer.html
@@ -3,7 +3,10 @@
     window.MathJax = {
       tex: {
         // https://docs.mathjax.org/en/latest/input/tex/delimiters.html#tex-and-latex-math-delimiters
-        inlineMath: [['$', '$'], ['\\(', '\\)']]
+        inlineMath: [['$', '$'], ['\\(', '\\)']],
+        // To use Doxygen delimiters, we could set:
+        // inlineMath: [[ '\\f$', '\\f$']],
+        // displayMath: [[ '\\f[', '\\f]']],
       }
     };
   </script>


### PR DESCRIPTION
This works when rendering via Markdown. For direct output as HTML, one
would need to manually inject the corresponding MathJax setup in the
HTML.

Fixes #53.