### PR TITLE
Add --group-uncommented

### DIFF
--- a/include/standardese/comment.hpp
+++ b/include/standardese/comment.hpp
@@ -22,9 +22,7 @@ class cpp_file;
 
 namespace standardese
 {
-/// The registry of the comments for all entities.
-///
-/// It also stores all member groups.
+/// A registry of the comments for all entities.
 class comment_registry
 {
 public:
@@ -76,27 +74,34 @@ private:
 /// \returns The unique name of the given entity.
 std::string lookup_unique_name(const comment_registry& registry, const cppast::cpp_entity& e);
 
-/// Parses the comments in a file.
+/// Parses the comments in several files and connects them in a shared registry.
 class file_comment_parser
 {
 public:
-    /// \effects Gives it the logger and comment configuration.
     explicit file_comment_parser(type_safe::object_ref<const cppast::diagnostic_logger> logger,
                                  comment::config config = comment::config())
     : config_(std::move(config)), logger_(logger)
     {}
 
-    /// \effects Parses all comments in the given file.
-    /// \notes This function is thread safe.
+    /// Parse all comments in `file`.
+    /// \notes This function is thread-safe.
     void parse(type_safe::object_ref<const cppast::cpp_file> file) const;
 
-    /// \effects Finishes parsing of the comments.
+    /// Create a registry from this parser.
     /// \returns The registry containing all registered comments.
     /// \requires This function must only be called once,
     /// and you must not call `parse()` afterwards.
     comment_registry finish();
 
 private:
+    /// Connect free comments with an `\entity` command to their respective entities.
+    /// \notes This function is not thread-safe.
+    void resolve_free_comments();
+
+    /// Group uncommented entities with preceding commented entities.
+    /// \notes This function is not thread-safe.
+    void group_uncommented();
+
     bool register_commented(type_safe::object_ref<const cppast::cpp_entity> entity,
                             comment::doc_comment comment, bool allow_cmd = true) const;
 

--- a/include/standardese/comment/config.hpp
+++ b/include/standardese/comment/config.hpp
@@ -26,6 +26,9 @@ namespace standardese::comment
             /// Whether commands should be applied to the entire file if they
             /// cannot be matched to another entity.
             bool free_file_comments = false;
+            /// Whether uncommented entities should be automatically grouped
+            /// with preceding commented entities.
+            bool group_uncommented = false;
             /// Override or complement command patterns with the ones giving
             /// here, e.g., `brief=SUMMARY:` lets us write `SUMMARY:` instead of
             /// `\brief`.
@@ -54,6 +57,12 @@ namespace standardese::comment
         /// command.
         bool free_file_comments() const {
             return free_file_comments_;
+        }
+
+        /// \returns Whether uncommented entities should be automatically
+        /// grouped with preceding commented entities.
+        bool group_uncommented() const {
+            return group_uncommented_;
         }
 
     private:
@@ -85,6 +94,7 @@ namespace standardese::comment
         std::vector<std::regex> inline_command_patterns_;
 
         bool free_file_comments_;
+        bool group_uncommented_;
     };
 }
 

--- a/news/group-uncommented.rst
+++ b/news/group-uncommented.rst
@@ -1,0 +1,16 @@
+**Added:**
+
+* Added command line option `--group-uncommented` to add uncommented members to
+  the group of the preceding member, e.g., here both operators are put in the
+  same group `Arithmetic` without having to explicitly mention the group for
+  the second line.
+  ```cpp
+  struct S {
+      /// \group Arithmetic
+      S& operator+=(const S&);
+      S& operator-=(const S&);
+  }
+  ```
+**Fixed:**
+
+* Added a missing mutex lock in the comment parser.

--- a/src/comment.cpp
+++ b/src/comment.cpp
@@ -5,6 +5,7 @@
 #include <cassert>
 #include <algorithm>
 #include <unordered_set>
+#include <stack>
 
 #include <standardese/comment.hpp>
 

--- a/src/comment/config.cpp
+++ b/src/comment/config.cpp
@@ -77,7 +77,7 @@ std::string config::default_command_pattern(char command_character, inline_type 
     return prefix + command_name(cmd) + boundary + word;
 }
 
-config::config(const options& options) : free_file_comments_(options.free_file_comments)
+config::config(const options& options) : free_file_comments_(options.free_file_comments), group_uncommented_(options.group_uncommented)
 {
     const auto pattern = [&](const auto command) {
         const std::string name = command_name(command);

--- a/test/comment.cpp
+++ b/test/comment.cpp
@@ -15,7 +15,7 @@
 
 #include "test_parser.hpp"
 
-using namespace standardese;
+namespace standardese::test {
 
 template <class Container>
 void test_comments(const comment_registry& registry, const Container& container)
@@ -38,19 +38,19 @@ TEST_CASE("comment")
     SECTION("matched comments")
     {
         auto file = parse_file({}, "comment_matched_comments.cpp", R"(
-/// \module a
-using a = int;
+            /// \module a
+            using a = int;
 
-/// \module b
-struct b {};
+            /// \module b
+            struct b {};
 
-/// \module c
-enum class c
-{
-    d, //< \module d
-    e, //< \module e
-};
-)");
+            /// \module c
+            enum class c
+            {
+                d, //< \module d
+                e, //< \module e
+            };
+            )");
 
         file_comment_parser parser(test_logger());
         parser.parse(type_safe::ref(*file));
@@ -59,17 +59,17 @@ enum class c
     SECTION("param")
     {
         auto file = parse_file({}, "comment_param.cpp", R"(
-/// \module a
-///
-/// \param b
-/// \module b
-///
-/// \param c
-/// \module c
-///
-/// \param 2
-void a(int b, int c, int);
-)");
+            /// \module a
+            ///
+            /// \param b
+            /// \module b
+            ///
+            /// \param c
+            /// \module c
+            ///
+            /// \param 2
+            void a(int b, int c, int);
+            )");
 
         file_comment_parser parser(test_logger());
         parser.parse(type_safe::ref(*file));
@@ -79,18 +79,18 @@ void a(int b, int c, int);
     SECTION("tparam")
     {
         auto file = parse_file({}, "comment_tparam.cpp", R"(
-/// \module a
-///
-/// \tparam b
-/// \module b
-///
-/// \tparam c
-/// \module c
-///
-/// \tparam 2
-template <int b, int c, int>
-void a();
-)");
+            /// \module a
+            ///
+            /// \tparam b
+            /// \module b
+            ///
+            /// \tparam c
+            /// \module c
+            ///
+            /// \tparam 2
+            template <int b, int c, int>
+            void a();
+            )");
 
         file_comment_parser parser(test_logger());
         parser.parse(type_safe::ref(*file));
@@ -100,18 +100,18 @@ void a();
     SECTION("base")
     {
         auto file = parse_file({}, "comment_base.cpp", R"(
-struct b {};
-struct c {};
+            struct b {};
+            struct c {};
 
-/// \module a
-///
-/// \base b
-/// \module b
-///
-/// \base c
-/// \module c
-struct a : b, c {};
-)");
+            /// \module a
+            ///
+            /// \base b
+            /// \module b
+            ///
+            /// \base c
+            /// \module c
+            struct a : b, c {};
+            )");
 
         file_comment_parser parser(test_logger());
         parser.parse(type_safe::ref(*file));
@@ -121,44 +121,44 @@ struct a : b, c {};
     SECTION("remote")
     {
         auto file = parse_file({}, "comment_remote.cpp", R"(
-/// \file
-/// \module comment_remote.cpp
+            /// \file
+            /// \module comment_remote.cpp
 
-/// \entity a
-/// \module a
+            /// \entity a
+            /// \module a
 
-/// \entity foo<T>::a
-/// \module a
+            /// \entity foo<T>::a
+            /// \module a
 
-/// \entity foo<T>.T
-/// \module T
+            /// \entity foo<T>.T
+            /// \module T
 
-/// \entity foo<T>::b(int, float).i
-/// \module i
+            /// \entity foo<T>::b(int, float).i
+            /// \module i
 
-/// \entity foo<T>::b(int, float)
-/// \module b
+            /// \entity foo<T>::b(int, float)
+            /// \module b
 
-/// \entity custom
-/// \module c
+            /// \entity custom
+            /// \module c
 
-/// \entity custom::foo<int>
-/// \module foo<int>
+            /// \entity custom::foo<int>
+            /// \module foo<int>
 
-struct a {};
+            struct a {};
 
-/// \module foo
-template <typename T>
-struct foo : a
-{
-    /// \param j
-    /// \module j
-    void b(int i, float j);
-};
+            /// \module foo
+            template <typename T>
+            struct foo : a
+            {
+                /// \param j
+                /// \module j
+                void b(int i, float j);
+            };
 
-/// \unique_name custom
-struct c : foo<int> {};
-)");
+            /// \unique_name custom
+            struct c : foo<int> {};
+            )");
 
         file_comment_parser parser(test_logger());
         parser.parse(type_safe::ref(*file));
@@ -189,24 +189,24 @@ struct c : foo<int> {};
     SECTION("member groups")
     {
         auto file = parse_file({}, "comment_member_groups.cpp", R"(
-/// \group a
-void a();
+            /// \group a
+            void a();
 
-/// \group b Heading
-void b();
+            /// \group b Heading
+            void b();
 
-/// \group a
-void a(int);
+            /// \group a
+            void a(int);
 
-/// \group b
-void b(int);
+            /// \group b
+            void b(int);
 
-/// \group c
-void c();
+            /// \group c
+            void c();
 
-/// \group a
-void a(float);
-)");
+            /// \group a
+            void a(float);
+            )");
 
         file_comment_parser parser(test_logger());
         parser.parse(type_safe::ref(*file));
@@ -232,12 +232,12 @@ void a(float);
         // set synopsis to same name as module
         // this doesn't make any sense, but is sufficient for testing here
         auto file = parse_file({}, "comment_module.cpp", R"(
-/// \module foo
-/// \synopsis foo
+            /// \module foo
+            /// \synopsis foo
 
-/// \module bar
-/// \synopsis bar
-)");
+            /// \module bar
+            /// \synopsis bar
+            )");
 
         file_comment_parser parser(test_logger());
         parser.parse(type_safe::ref(*file));
@@ -254,8 +254,8 @@ void a(float);
     SECTION("free file comments")
     {
         auto file = parse_file({}, "file_comment.hpp", R"(
-/// Here we explain what this header file is about.
-)");
+            /// Here we explain what this header file is about.
+            )");
 
         comment::config::options options;
         options.free_file_comments = true;
@@ -263,4 +263,29 @@ void a(float);
         parser.parse(type_safe::ref(*file));
         auto comments = parser.finish();
     }
+
+    SECTION("Group Uncommented Members")
+    {
+        auto file = parse_file({}, "groups.hpp", R"(
+            /// This struct has some arithmetic operators.
+            struct S {
+                /// \group Arithmetic
+                /// Here are the arithmetic operators.
+                S& operator+=(const S&);
+                S& operator-=(const S&);
+            };
+            )");
+
+
+        comment::config::options options;
+        options.group_uncommented = true;
+        file_comment_parser parser(test_logger(), comment::config(options));
+        parser.parse(type_safe::ref(*file));
+        auto comments = parser.finish();
+
+        const auto& group = comments.lookup_group("Arithmetic");
+        CHECK(static_cast<size_t>(group.size()) == 2);
+    }
+}
+
 }

--- a/test/test_parser.hpp
+++ b/test/test_parser.hpp
@@ -16,6 +16,7 @@
 #include <standardese/doc_entity.hpp>
 
 #include "test_logger.hpp"
+#include "util/indent.hpp"
 
 inline std::unique_ptr<cppast::cpp_file> parse_file(const cppast::cpp_entity_index& idx,
                                                     const char* name, const char* content)
@@ -25,7 +26,7 @@ inline std::unique_ptr<cppast::cpp_file> parse_file(const cppast::cpp_entity_ind
     config.set_flags(cppast::cpp_standard::cpp_latest);
 
     std::ofstream file(name);
-    file << content;
+    file << standardese::test::util::unindent(content);
     file.close();
 
     return parser.parse(idx, name, config);

--- a/tool/main.cpp
+++ b/tool/main.cpp
@@ -200,6 +200,7 @@ standardese::comment::config get_comment_config(const po::variables_map& variabl
     standardese::comment::config::options options;
     options.command_character = get_option<char>(variables, "comment.command_character").value();
     options.free_file_comments = get_option<bool>(variables, "comment.free_file_comments").value();
+    options.group_uncommented = get_option<bool>(variables, "comment.group_uncommented").value();
     options.command_patterns = get_option<std::vector<std::string>>(variables, "comment.command_pattern").value();
 
     return standardese::comment::config(options);
@@ -384,7 +385,10 @@ int main(int argc, char* argv[])
          "set the regular expression to detect a command, e.g., `--comment.command_pattern 'returns=RETURNS:'` or `'returns|=RETURNS:'` to also keep the original pattern.")
         ("comment.external_doc", po::value<std::vector<std::string>>()->default_value({}, ""),
          "syntax is namespace=url, supports linking to a different URL for entities in a certain namespace")
-        ("comment.free_file_comments", po::value<bool>()->implicit_value(true)->default_value(standardese::comment::config::options().free_file_comments))
+        ("comment.free_file_comments", po::value<bool>()->implicit_value(true)->default_value(standardese::comment::config::options().free_file_comments),
+         "associate free comments to their entire file")
+        ("comment.group_uncommented", po::value<bool>()->implicit_value(true)->default_value(standardese::comment::config::options().group_uncommented),
+         "group undocumented members with preceding commented members")
 
         ("output.prefix",
          po::value<std::string>()->default_value(""),


### PR DESCRIPTION
for automatic grouping of uncommented entities with previous groups.