### PR TITLE
New CLI flag: `keep_comments_in_macro`.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ if (MSVC)
         )
 endif()
 
+set(CMAKE_EXPORT_COMPILE_COMMANDS on)
+
 # subdirectories
 add_subdirectory(src)
 if(STANDARDESE_BUILD_TOOL)

--- a/news/keep_comments_in_macro_flag.rst
+++ b/news/keep_comments_in_macro_flag.rst
@@ -1,0 +1,3 @@
+**Fixed:**
+
+* Failure to parse files that use Boost ASIO and others that depend on Boost.MPL, by enabling cppast `remove_comments_in_macro` feature by default and providing a CLI flag to disable it.

--- a/tool/main.cpp
+++ b/tool/main.cpp
@@ -74,9 +74,6 @@ po::variables_map get_options(int argc, char* argv[], const po::options_descript
         if (!config.is_open())
             throw std::runtime_error("config file '" + path.generic_string() + "' not found");
 
-        po::options_description conf;
-        conf.add(configuration);
-
         file_result = po::parse_config_file(config, configuration, true);
         po::store(file_result, map);
         po::notify(map);

--- a/tool/main.cpp
+++ b/tool/main.cpp
@@ -125,7 +125,7 @@ cppast::libclang_compile_config get_compile_config(const po::variables_map& opti
 {
     cppast::libclang_compile_config config;
 
-    config.remove_comments_in_macro(!get_option<bool>(options, "compilation.do_not_remove_comments_in_macro").value());
+    config.remove_comments_in_macro(!get_option<bool>(options, "compilation.keep_comments_in_macro").value());
 
     cppast::compile_flags flags;
     if (auto gnu_ext = get_option<bool>(options, "compilation.gnu_extensions"))
@@ -383,9 +383,9 @@ int main(int argc, char* argv[])
         ("compilation.ms_compatibility",
          po::value<bool>()->implicit_value(true)->default_value(default_msvc_comp()),
          "enable/disable MSVC compatibility (-fms-compatibility)")
-        ("compilation.do_not_remove_comments_in_macro",
+        ("compilation.keep_comments_in_macro",
          po::value<bool>()->implicit_value(true)->default_value(false),
-         "enable/disable removal of comments during macro evaluation")
+         "disable/enable removal of comments during macro evaluation (-CC)")
 
         ("comment.command_character", po::value<char>()->default_value(standardese::comment::config::options().command_character),
          "character used to introduce special commands")

--- a/tool/main.cpp
+++ b/tool/main.cpp
@@ -125,6 +125,8 @@ cppast::libclang_compile_config get_compile_config(const po::variables_map& opti
 {
     cppast::libclang_compile_config config;
 
+    config.remove_comments_in_macro(!get_option<bool>(options, "compilation.do_not_remove_comments_in_macro").value());
+
     cppast::compile_flags flags;
     if (auto gnu_ext = get_option<bool>(options, "compilation.gnu_extensions"))
         flags.set(cppast::compile_flag::gnu_extensions, gnu_ext.value());
@@ -381,6 +383,9 @@ int main(int argc, char* argv[])
         ("compilation.ms_compatibility",
          po::value<bool>()->implicit_value(true)->default_value(default_msvc_comp()),
          "enable/disable MSVC compatibility (-fms-compatibility)")
+        ("compilation.do_not_remove_comments_in_macro",
+         po::value<bool>()->implicit_value(true)->default_value(false),
+         "enable/disable removal of comments during macro evaluation")
 
         ("comment.command_character", po::value<char>()->default_value(standardese::comment::config::options().command_character),
          "character used to introduce special commands")


### PR DESCRIPTION
Fixes #206. This potentially allows practically any project that uses Boost ASIO (and not only) to be correctly parsed by standardese by default.

This PR adds the new flag and exports compile_commands.json by default.