### PR TITLE
Fix build with Boost 1.89.0

### DIFF
--- a/tool/CMakeLists.txt
+++ b/tool/CMakeLists.txt
@@ -11,7 +11,10 @@ target_include_directories(standardese_tool PUBLIC $<BUILD_INTERFACE:${THREADPOO
 set_target_properties(standardese_tool PROPERTIES OUTPUT_NAME standardese CXX_STANDARD 17)
 
 # link Boost
-find_package(Boost COMPONENTS program_options filesystem system REQUIRED)
+find_package(Boost COMPONENTS program_options filesystem REQUIRED)
+if(Boost_MAJOR_VERSION EQUAL 1 AND Boost_MINOR_VERSION LESS 69)
+    find_package(Boost COMPONENTS program_options filesystem system REQUIRED)
+endif()
 target_include_directories(standardese_tool PUBLIC ${Boost_INCLUDE_DIR})
 target_link_libraries(standardese_tool PUBLIC ${Boost_LIBRARIES})
 


### PR DESCRIPTION
In the upcoming Boost 1.89.0 release, Boost.System stub has been removed (https://github.com/boostorg/system/commit/7a495bb46d7ccd808e4be2a6589260839b0fd3a3) which causes CMake error:

```
CMake Error at /opt/homebrew/lib/cmake/Boost-1.89.0/BoostConfig.cmake:141 (find_package):
  Could not find a package configuration file provided by "boost_system"
  (requested version 1.89.0) with any of the following names:

    boost_systemConfig.cmake
    boost_system-config.cmake
```

The Boost.System library has been header-only since 1.69[^1].

I wasn't sure if there is a minimum Boost version for standardese, so I just used upstream's suggestion of `OPTIONAL_COMPONENTS`.

[^1]: https://www.boost.org/doc/libs/1_69_0/libs/system/doc/html/system.html#changes_in_boost_1_69