### PR TITLE
standardese now compiles and installs on MacOSX latest.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # This file is subject to the license terms in the LICENSE file
 # found in the top-level directory of this distribution.
 
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.5)
 project(STANDARDESE VERSION 0.5.2)
 
 option(STANDARDESE_BUILD_TOOL "Build the standardese binary" ON)
@@ -38,5 +38,5 @@ if (STANDARDESE_BUILD_TEST)
 endif()
 
 # install configuration
-#install(EXPORT standardese DESTINATION "${lib_dest}")
-#install(FILES standardese-config.cmake LICENSE DESTINATION "${lib_dest}")
+install(EXPORT standardese DESTINATION "${lib_dest}")
+install(FILES standardese-config.cmake LICENSE DESTINATION "${lib_dest}")

--- a/external/external.cmake
+++ b/external/external.cmake
@@ -35,8 +35,9 @@ if((NOT CMARK_LIBRARY) OR (NOT CMARK_INCLUDE_DIR))
 
     # add and exclude targets
     add_subdirectory(external/cmark ${CMAKE_CURRENT_BINARY_DIR}/cmark EXCLUDE_FROM_ALL)
-    set_target_properties(api_test PROPERTIES EXCLUDE_FROM_ALL 1)
-
+    if(CMARK_TESTS AND (CMARK_SHARED OR CMARK_STATIC))
+      set_target_properties(api_test PROPERTIES EXCLUDE_FROM_ALL 1)
+    endif()
     # fixup target properties
     target_include_directories(libcmark-gfm_static SYSTEM PUBLIC
                                $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}/cmark/src>


### PR DESCRIPTION
standardese now compiles and installs on MacOSX latest with the following cmake flags:

"cmake.configureArgs": [
                "-DCMAKE_POLICY_VERSION_MINIMUM=3.5",
                "-DCMARK_TESTS=OFF",
                "-DSTANDARDESE_BUILD_TEST=off",
                "-DTYPE_SAFE_BUILD_TEST_EXAMPLE=off"
        ]
}

Fixed the following issues:

1. Updated the cmark sub-module version to the head of that library to overcome errors compiling with a newer cmake.
2. Upped the required minimum cmake version into the main CMakeLists.txt to the mimimum supported by newer cmakes.
3. Added a missing cmake check for tests being off to allow proper compilation.